### PR TITLE
fix: when sending a log event use the rendered message

### DIFF
--- a/LoggerConfigurationsLMExtensions.cs
+++ b/LoggerConfigurationsLMExtensions.cs
@@ -3,6 +3,7 @@ using Serilog.Events;
 using configuration = LogicMonitor.DataSDK.Configuration;
 using LogicMonitor.DataSDK.Model;
 using Serilog.Sinks.LogicMonitor;
+using System;
 
 namespace Serilog
 {
@@ -14,10 +15,11 @@ namespace Serilog
             Resource resource = null,
             bool batch = true,
             int interval = 10,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            IFormatProvider formatProvider = null
             )
         {
-            var lmSink = new LogicmonitorSink(configuration, resource, batch, interval);
+            var lmSink = new LogicmonitorSink(configuration, resource, batch, interval, formatProvider);
             return loggerSinkConfiguration.Sink(lmSink, restrictedToMinimumLevel);
         }
     }

--- a/LogicmonitorSink.cs
+++ b/LogicmonitorSink.cs
@@ -10,17 +10,18 @@ namespace Serilog.Sinks.LogicMonitor
 {
     public class LogicmonitorSink : ILogEventSink
     {
+        private readonly IFormatProvider formatProvider;
         Logs Logs;
         conf Configuration;
         Resource Resource;
 
-        public LogicmonitorSink(conf conf = null, Resource resource = null, bool batch = true, int interval = 10)
+        public LogicmonitorSink(conf conf = null, Resource resource = null, bool batch = true, int interval = 10, IFormatProvider formatProvider = null)
         {
             Configuration = conf ??= new conf();
             ApiClient apiClient = new ApiClient(Configuration);
             Resource = resource ??= new Resource();
             Logs = new Logs(batch: batch, interval: interval, apiClient: apiClient);
-
+            this.formatProvider = formatProvider;
         }
 
         /// <summary>
@@ -29,10 +30,7 @@ namespace Serilog.Sinks.LogicMonitor
         /// <param name="events">The events to emit.</param>
         public void Emit(LogEvent logEvent)
         {
-            var response = Logs.SendLogs(message: logEvent.MessageTemplate.Text, resource: Resource);
+            var response = Logs.SendLogs(message: logEvent.RenderMessage(formatProvider), resource: Resource);
         }
-
-        
-
     }
 }


### PR DESCRIPTION
fix: when sending a log event use the rendered message instead of the template's text.

Because Serilog supports structured events the template's text often needs rendering in order to insert property values.

These changes are to fix #3.